### PR TITLE
Add `Array<T>.{min, max}(by: (Element) -> {T, T?}) -> T?`

### DIFF
--- a/Sources/SchafKit/Extensions/Collections/Array.swift
+++ b/Sources/SchafKit/Extensions/Collections/Array.swift
@@ -107,7 +107,7 @@ public extension Array {
     /// ["foo", "bar", "toast"].max(of: \.count)
     /// ```
     ///
-    /// - Parameter of: A function/keypath returning the value to be compared.
+    /// - Parameter mappingFunc: A function/keypath returning the value to be compared.
     func max<T: Comparable>(of mappingFunc: (Element) -> T) -> T? {
         self.map(mappingFunc).max()
     }
@@ -118,7 +118,7 @@ public extension Array {
     /// ["foo", "bar", "toast"].max(of: \.count)
     /// ```
     ///
-    /// - Parameter of: A function/keypath returning the optional value to be compared.
+    /// - Parameter mappingFunc: A function/keypath returning the optional value to be compared.
     func max<T: Comparable>(of mappingFunc: (Element) -> T?) -> T? {
         self.compactMap(mappingFunc).max()
     }
@@ -129,7 +129,7 @@ public extension Array {
     /// ["foo", "bar", "toast"].min(of: \.count)
     /// ```
     ///
-    /// - Parameter of: A function/keypath returning the value to be compared.
+    /// - Parameter mappingFunc: A function/keypath returning the value to be compared.
     func min<T: Comparable>(of mappingFunc: (Element) -> T) -> T? {
         self.map(mappingFunc).min()
     }
@@ -140,7 +140,7 @@ public extension Array {
     /// ["foo", "bar", "toast"].min(of: \.count)
     /// ```
     ///
-    /// - Parameter of: A function/keypath returning the optional value to be compared.
+    /// - Parameter mappingFunc: A function/keypath returning the optional value to be compared.
     func min<T: Comparable>(of mappingFunc: (Element) -> T?) -> T? {
         self.compactMap(mappingFunc).min()
     }

--- a/Sources/SchafKit/Extensions/Collections/Array.swift
+++ b/Sources/SchafKit/Extensions/Collections/Array.swift
@@ -108,8 +108,8 @@ public extension Array {
     /// ```
     ///
     /// - Parameter f: A function/keypath returning the value to be compared.
-    func max<T: Comparable>(by f: (Element) -> T) -> T? {
-        self.map(f).max()
+    func max<T: Comparable>(of mappingFunc: (Element) -> T) -> T? {
+        self.map(mappingFunc).max()
     }
     
     /// Get the max value of a field of the array element type.
@@ -119,8 +119,8 @@ public extension Array {
     /// ```
     ///
     /// - Parameter f: A function/keypath returning the optional value to be compared.
-    func max<T: Comparable>(by f: (Element) -> T?) -> T? {
-        self.compactMap(f).max()
+    func max<T: Comparable>(of mappingFunc: (Element) -> T?) -> T? {
+        self.compactMap(mappingFunc).max()
     }
     
     /// Get the min value of a field of the array element type.
@@ -130,8 +130,8 @@ public extension Array {
     /// ```
     ///
     /// - Parameter f: A function/keypath returning the value to be compared.
-    func min<T: Comparable>(by f: (Element) -> T) -> T? {
-        self.map(f).min()
+    func min<T: Comparable>(of mappingFunc: (Element) -> T) -> T? {
+        self.map(mappingFunc).min()
     }
     
     /// Get the min value of a field of the array element type.
@@ -141,8 +141,8 @@ public extension Array {
     /// ```
     ///
     /// - Parameter f: A function/keypath returning the optional value to be compared.
-    func min<T: Comparable>(by f: (Element) -> T?) -> T? {
-        self.compactMap(f).min()
+    func min<T: Comparable>(of mappingFunc: (Element) -> T?) -> T? {
+        self.compactMap(mappingFunc).min()
     }
 }
 

--- a/Sources/SchafKit/Extensions/Collections/Array.swift
+++ b/Sources/SchafKit/Extensions/Collections/Array.swift
@@ -100,6 +100,50 @@ public extension Array {
         }
         return false
     }
+    
+    /// Get the max value of a field of the array element type.
+    ///
+    /// ```
+    /// ["foo", "bar", "toast"].max(by: \.count)
+    /// ```
+    ///
+    /// - Parameter f: A function/keypath returning the value to be compared.
+    func max<T: Comparable>(by f: (Element) -> T) -> T? {
+        self.map(f).max()
+    }
+    
+    /// Get the max value of a field of the array element type.
+    ///
+    /// ```
+    /// ["foo", "bar", "toast"].max(by: \.count)
+    /// ```
+    ///
+    /// - Parameter f: A function/keypath returning the optional value to be compared.
+    func max<T: Comparable>(by f: (Element) -> T?) -> T? {
+        self.compactMap(f).max()
+    }
+    
+    /// Get the min value of a field of the array element type.
+    ///
+    /// ```
+    /// ["foo", "bar", "toast"].min(by: \.count)
+    /// ```
+    ///
+    /// - Parameter f: A function/keypath returning the value to be compared.
+    func min<T: Comparable>(by f: (Element) -> T) -> T? {
+        self.map(f).min()
+    }
+    
+    /// Get the min value of a field of the array element type.
+    ///
+    /// ```
+    /// ["foo", "bar", "toast"].min(by: \.count)
+    /// ```
+    ///
+    /// - Parameter f: A function/keypath returning the optional value to be compared.
+    func min<T: Comparable>(by f: (Element) -> T?) -> T? {
+        self.compactMap(f).min()
+    }
 }
 
 public extension Array where Element : Equatable {

--- a/Sources/SchafKit/Extensions/Collections/Array.swift
+++ b/Sources/SchafKit/Extensions/Collections/Array.swift
@@ -104,10 +104,10 @@ public extension Array {
     /// Get the max value of a field of the array element type.
     ///
     /// ```
-    /// ["foo", "bar", "toast"].max(by: \.count)
+    /// ["foo", "bar", "toast"].max(of: \.count)
     /// ```
     ///
-    /// - Parameter f: A function/keypath returning the value to be compared.
+    /// - Parameter of: A function/keypath returning the value to be compared.
     func max<T: Comparable>(of mappingFunc: (Element) -> T) -> T? {
         self.map(mappingFunc).max()
     }
@@ -115,10 +115,10 @@ public extension Array {
     /// Get the max value of a field of the array element type.
     ///
     /// ```
-    /// ["foo", "bar", "toast"].max(by: \.count)
+    /// ["foo", "bar", "toast"].max(of: \.count)
     /// ```
     ///
-    /// - Parameter f: A function/keypath returning the optional value to be compared.
+    /// - Parameter of: A function/keypath returning the optional value to be compared.
     func max<T: Comparable>(of mappingFunc: (Element) -> T?) -> T? {
         self.compactMap(mappingFunc).max()
     }
@@ -126,10 +126,10 @@ public extension Array {
     /// Get the min value of a field of the array element type.
     ///
     /// ```
-    /// ["foo", "bar", "toast"].min(by: \.count)
+    /// ["foo", "bar", "toast"].min(of: \.count)
     /// ```
     ///
-    /// - Parameter f: A function/keypath returning the value to be compared.
+    /// - Parameter of: A function/keypath returning the value to be compared.
     func min<T: Comparable>(of mappingFunc: (Element) -> T) -> T? {
         self.map(mappingFunc).min()
     }
@@ -137,10 +137,10 @@ public extension Array {
     /// Get the min value of a field of the array element type.
     ///
     /// ```
-    /// ["foo", "bar", "toast"].min(by: \.count)
+    /// ["foo", "bar", "toast"].min(of: \.count)
     /// ```
     ///
-    /// - Parameter f: A function/keypath returning the optional value to be compared.
+    /// - Parameter of: A function/keypath returning the optional value to be compared.
     func min<T: Comparable>(of mappingFunc: (Element) -> T?) -> T? {
         self.compactMap(mappingFunc).min()
     }


### PR DESCRIPTION
Swift has lots of potential for map-reduce-type operations.
This PR proposes four functions to turn various map-reduce-workflow into a single operation:

```swift
Array<T>.min(of: (Element) -> T) -> T?
Array<T>.min(of: (Element) -> T?) -> T?
Array<T>.max(of: (Element) -> T) -> T?
Array<T>.max(of: (Element) -> T?) -> T?
```

Example usage:
```swift
// Get count of longest word in array
["hello", "toast", nil, "foo"].max(of: \.count) ?? 0
```