### PR TITLE
Add Swift workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,19 @@
+name: Swift
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: macos-latest
     
     steps:
+    - uses: actions/checkout@v2
     - uses: fwal/setup-swift@v1
       with:
         swift-version: "5.3"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,18 +1,16 @@
 name: Swift
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v2
+    
+    - uses: fwal/setup-swift@v1
+      with:
+        swift-version: "5.3"
+    - name: Get swift version
+      run: swift --version
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: macos-latest
     
+    steps:
     - uses: fwal/setup-swift@v1
       with:
         swift-version: "5.3"

--- a/Sources/SchafKit/Extensions/Generic/String+Markdown.swift
+++ b/Sources/SchafKit/Extensions/Generic/String+Markdown.swift
@@ -166,7 +166,7 @@ public extension String {
      *           - String b should be inserted else
      */
     @available(macOS 10.16, *)
-    func markdownedText(with font: Font = .body, with arguments: [String] = []) -> Text {
+    func markdownedText(with font: Font = .body, arguments: [String] = []) -> Text {
         
         var isBold = false
         var isItalic = false

--- a/Sources/SchafKit/Extensions/UIKit+AppKit/UIImage.swift
+++ b/Sources/SchafKit/Extensions/UIKit+AppKit/UIImage.swift
@@ -244,4 +244,22 @@ public extension UIImage {
         self.init(named: name, in: bundle, compatibleWith: nil)
     }
     #endif
+    
+    #if os(macOS)
+    extension NSImage {
+        func tinted(with color: NSColor) -> NSImage {
+            let image = self.copy() as! NSImage
+            image.lockFocus()
+
+            color.set()
+
+            let imageRect = NSRect(origin: NSZeroPoint, size: image.size)
+            imageRect.fill(using: .sourceAtop)
+
+            image.unlockFocus()
+
+            return image
+        }
+    }
+    #endif
 }

--- a/Sources/SchafKit/Kit/SwiftUI/Components/AFText.swift
+++ b/Sources/SchafKit/Kit/SwiftUI/Components/AFText.swift
@@ -33,6 +33,6 @@ public struct AFText: View {
     }
     
     public var body: some View {
-        text.localized.markdownedText(with: font ?? .body, with: arguments)
+        text.localized.markdownedText(with: font ?? .body, arguments: arguments)
     }
 }

--- a/Tests/SchafKitTests/Extensions/UIKit+AppKit/UIColor.swift
+++ b/Tests/SchafKitTests/Extensions/UIKit+AppKit/UIColor.swift
@@ -27,7 +27,11 @@ class UIColorTests : XCTestCase {
     }
     
     func testCatalogRepresentation() {
+        #if os(macOS)
         let background = UIColor.textBackgroundColor
+        #else
+        let background = UIColor.placeholderText
+        #endif
         
         XCTAssertTrue(background.rgbaRepresentation.red > 0)
     }


### PR DESCRIPTION
Create GitHub action workflow for building and testing SchafKit on macOS.

## Issues
~Currently these tests are failing because the Swift distribution used in the workflow doesn't recognize new features of SwiftUI, which cause it to break. I'm looking into whether this can be fixed.~

After updating the workflow, we're getting another error.
The issue is being tracked at: https://github.com/fwal/setup-swift/issues/133

Generally, another issue is that this only tests the macOS-specific code.
Not sure if there's any way to actually test the iOS-specific code in an automated fashion.