### PR TITLE
Fix String Tests

### DIFF
--- a/Sources/SchafKit/Extensions/Generic/String.swift
+++ b/Sources/SchafKit/Extensions/Generic/String.swift
@@ -169,10 +169,11 @@ public extension String {
     
      - Remark : Double() does not support optional chaining.
     */
-    func formattedToDouble(separatesThousands : Bool = true) -> Double?{
+    func formattedToDouble(separatesThousands : Bool = true, locale: Locale = .autoupdatingCurrent) -> Double?{
         let formatter = NumberFormatter()
         formatter.usesGroupingSeparator = separatesThousands
         formatter.groupingSize = 3
+        formatter.locale = locale
         return formatter.number(from: self)?.doubleValue
     }
     

--- a/Tests/SchafKitTests/Extensions/Scalar/String.swift
+++ b/Tests/SchafKitTests/Extensions/Scalar/String.swift
@@ -22,6 +22,7 @@
 import XCTest
 
 class StringTests : XCTestCase {
+    let locale = Locale(identifier: "en-US")
     
     override func setUp() {
         super.setUp()
@@ -195,11 +196,11 @@ class StringTests : XCTestCase {
     func testFormattedToDouble(){
         let string = "1,000,000.00"
         
-        XCTAssertEqual(string.formattedToDouble(), 1000000)
+        XCTAssertEqual(string.formattedToDouble(locale: locale), 1000000)
         
         let stringB = "1,000,000.005"
         
-        XCTAssertEqual(stringB.formattedToDouble(), 1000000.005)
+        XCTAssertEqual(stringB.formattedToDouble(locale: locale), 1000000.005)
     }
     
     func testExtractedSeconds() {


### PR DESCRIPTION
This PR fixes the string tests that fail because of the locale being different.