### PR TITLE
Fix Catalog Color Failure

### DIFF
--- a/Sources/SchafKit/Extensions/UIKit+AppKit/UIColor.swift
+++ b/Sources/SchafKit/Extensions/UIKit+AppKit/UIColor.swift
@@ -34,9 +34,6 @@ public extension UIColor {
         #if os(iOS)
         return self
         #else
-        if self.colorSpace == .sRGB {
-            return self
-        }
         return self.usingColorSpace(.sRGB)!
         #endif
     }

--- a/Tests/SchafKitTests/Extensions/UIKit+AppKit/UIColor.swift
+++ b/Tests/SchafKitTests/Extensions/UIKit+AppKit/UIColor.swift
@@ -25,5 +25,11 @@ class UIColorTests : XCTestCase {
         
         XCTAssertEqual(white.rgbaRepresentation.red, 1)
     }
+    
+    func testCatalogRepresentation() {
+        let background = UIColor.textBackgroundColor
+        
+        XCTAssertTrue(background.rgbaRepresentation.red > 0)
+    }
 }
 #endif


### PR DESCRIPTION
For catalog colors, the colorSpace cannot be received and throws an NSException crashing the app. This is fixed with this PR.