### PR TITLE
Various extensions ported from Voqab

### DIFF
--- a/Sources/SchafKit/Extensions/Generic/Bool.swift
+++ b/Sources/SchafKit/Extensions/Generic/Bool.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Bool {
+    
+    /// Returns the logical negation of the boolean value.
+    var negated: Bool {
+        !self
+    }
+}

--- a/Sources/SchafKit/Extensions/Generic/Date.swift
+++ b/Sources/SchafKit/Extensions/Generic/Date.swift
@@ -20,4 +20,16 @@ public extension Date {
     init(timeIntervalUntilNow: TimeInterval) {
         self.init(timeIntervalSinceNow: -timeIntervalUntilNow)
     }
+    
+    /// Returns the date with all time information stripped (excluding timezone).
+    var onlyDate: Date {
+        get {
+            let calendar = Calendar.current
+            var components = calendar.dateComponents(
+                [.year, .month, .day, .calendar, .timeZone], from: self
+            )
+            components.timeZone = TimeZone.autoupdatingCurrent
+            return calendar.date(from: components)!
+        }
+    }
 }

--- a/Sources/SchafKit/Extensions/Generic/String.swift
+++ b/Sources/SchafKit/Extensions/Generic/String.swift
@@ -275,6 +275,16 @@ public extension String {
         try data.append(to: filePath)
     }
     #endif
+    
+    /// Removes Unicode Object Replacement Markers from the string.
+    ///
+    /// **Context**
+    ///
+    /// For some reason, the dictation feature inserts this marker at the end of the string.
+    /// For RTL languages like arabic, it's at the beginning of the string.
+    func removingObjectReplacementMarkers() -> String {
+        return self.replacingOccurrences(of: "\u{fffc}", with: "", options: String.CompareOptions.literal, range: nil)
+    }
 }
 
 // - MARK: Identifiable

--- a/Sources/SchafKit/Extensions/Generic/TimeInterval.swift
+++ b/Sources/SchafKit/Extensions/Generic/TimeInterval.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension TimeInterval {
+    var minutes: Double {
+        self / 60
+    }
+    
+    var seconds: Double {
+        self
+    }
+}


### PR DESCRIPTION
- `Bool#negated: Bool`
- `Date#onlyDate: Date`
- `String#removingObjecReplacementMarkers() -> String`
- `TimeInterval#minutes: Double`
- `TimeInterval#seconds: Double`